### PR TITLE
Create serranoltexx.env

### DIFF
--- a/device-config/serranoltexx.env
+++ b/device-config/serranoltexx.env
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Repo and branch
+LINEAGEOS_REPO=https://github.com/LineageOS/android.git
+LINEAGEOS_BRANCH=cm-14.1
+
+DEVICE_CODENAME=serranoltexx
+
+# link to repo with the proprietary blobs
+# https://wiki.lineageos.org/devices/serranoltexx/build#extract-proprietary-blobs
+PROPRIETARY_BLOBS_REPO=https://github.com/TheMuppets/proprietary_vendor_samsung
+PROPRIETARY_BLOBS_DIR=$BASE_DIR/vendor/samsung


### PR DESCRIPTION
Create an env file for the Samsung Galaxy S4 Mini (International LTE).