### PR TITLE
Create espressowifi.env

### DIFF
--- a/device-config/espressowifi.env
+++ b/device-config/espressowifi.env
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Repo and branch
+LINEAGEOS_REPO=https://github.com/LineageOS/android.git
+LINEAGEOS_BRANCH=cm-14.1
+
+DEVICE_CODENAME=espressowifi
+
+# link to repo with the proprietary blobs
+# https://wiki.lineageos.org/devices/espressowifi/build#extract-proprietary-blobs
+PROPRIETARY_BLOBS_REPO=https://github.com/TheMuppets/proprietary_vendor_samsung
+PROPRIETARY_BLOBS_DIR=$BASE_DIR/vendor/samsung


### PR DESCRIPTION
Create an env file for the Samsung Galaxy Tab 2 7.0 / Tab 2 10.1 (Wi-Fi / Wi-Fi + IR).